### PR TITLE
Refactor fxprequests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -427,6 +427,13 @@
         "redis": "^2.8.0"
       }
     },
+    "@internal/fxpRequests": {
+      "version": "file:src/lib/model/lib/fxpRequests",
+      "requires": {
+        "request": "^2.34",
+        "request-promise-native": "^1.0.7"
+      }
+    },
     "@internal/log": {
       "version": "file:src/lib/log",
       "requires": {
@@ -436,6 +443,7 @@
     "@internal/model": {
       "version": "file:src/lib/model",
       "requires": {
+        "@internal/fxpRequests": "file:src/lib/model/lib/fxpRequests",
         "@internal/requests": "file:src/lib/model/lib/requests",
         "@internal/shared": "file:src/lib/model/lib/shared",
         "javascript-state-machine": "^3.1.0"

--- a/src/inboundApi/handlers.js
+++ b/src/inboundApi/handlers.js
@@ -13,7 +13,7 @@
 const util = require('util');
 const Model = require('@internal/model').inboundTransfersModel;
 const BackendRequests = require('@internal/requests').BackendRequests;
-
+const FxpBackendRequests = require('@internal/requests').FxpBackendRequests;
 
 /**
  * Handles a GET /participants/{idType}/{idValue} request 
@@ -205,13 +205,13 @@ const putQuoteById = async (ctx) => {
 
     // If forwarding (usually while the SDK is working as a passthrough or Hub emulator)
     if (ctx.state.conf.forwardPutQuotesToBackend) {
-        let backendRequests = new BackendRequests({
+        let fxpBackendRequests = new FxpBackendRequests({
             logger: ctx.state.logger,
             backendEndpoint: ctx.state.conf.backendEndpoint,
             dfspId: ctx.state.conf.dfspId
         });
         
-        let response = await backendRequests.postFxpQuoteResponse(ctx.state.path.params.ID, ctx.request.body.quoteResponse ? ctx.request.body.quoteResponse : ctx.request.body , 
+        let response = await fxpBackendRequests.postFxpQuoteResponse(ctx.state.path.params.ID, ctx.request.body.quoteResponse ? ctx.request.body.quoteResponse : ctx.request.body , 
             { ...ctx.request.headers, ...ctx.request.body.metadata });
         console.log('Sent PUT /quotes to backend and got back: ', response);
 
@@ -236,14 +236,14 @@ const putTransfersById = async (ctx) => {
     // If forwarding (usually while the SDK is working as a passthrough or Hub emulator)
     // FIXME implement forwardPutTransfersToBackend loading on config
     if (ctx.state.conf.forwardPutTransfersToBackend) {
-        let backendRequests = new BackendRequests({
+        let fxpBackendRequests = new FxpBackendRequests({
             logger: ctx.state.logger,
             backendEndpoint: ctx.state.conf.backendEndpoint,
             dfspId: ctx.state.conf.dfspId
         });
         
         // FIXME validate implementation
-        let response = await backendRequests.postFxpTransferResponse(ctx.state.path.params.ID, ctx.request.body, ctx.request.headers['fspiop-source'], ctx.request.headers['fspiop-destination']);
+        let response = await fxpBackendRequests.postFxpTransferResponse(ctx.state.path.params.ID, ctx.request.body, ctx.request.headers['fspiop-source'], ctx.request.headers['fspiop-destination']);
         console.log('Sent PUT /transfers to backend and got back: ', response);
 
     } else {

--- a/src/lib/model/lib/fxpRequests/fxpBackendRequests.js
+++ b/src/lib/model/lib/fxpRequests/fxpBackendRequests.js
@@ -28,9 +28,8 @@ const defaultFXPBackendHeaders = {
 };
 
 /**
- * A class for making requests to DFSP backend API
+ * A class for making requests to the FXP backend
  * 
- * / FIXME Move the specific FXP methods to another class, so this one can be pulled from the original sdk project
  */
 class FxpBackendRequests {
     constructor(config) {
@@ -45,32 +44,6 @@ class FxpBackendRequests {
 
         // Switch or peer DFSP endpoint
         this.backendEndpoint = `${this.transportScheme}://${config.backendEndpoint}`;
-    }
-
-
-    /**
-     * Executes a POST /quotes request for the specified quote request
-     *
-     * @returns {object} - JSON response body if one was received
-     */
-    async postQuotes(quoteRequest, headers) {
-        // FIXME I think this is not ever called
-        throw new Error('IT WAS CALLED');
-        const newHeaders = {
-            accept: headers.accept,
-            'content-type': headers['content-type'],
-            date: headers.date,
-            'fspiop-source': headers['fspiop-source'],
-            'fspiop-destination': headers['fspiop-destination'],
-            'fspiop-signature': headers['fspiop-signature'],
-            'fspiop-http-method': headers['fspiop-http-method'],
-            'fspiop-uri': headers['fspiop-uri'],
-            'fspiop-sourcecurrency': headers['fspiop-sourcecurrency'],
-            'fspiop-destinationcurrency': headers['fspiop-destinationcurrency'],
-            authorization: headers.authorization
-        };
-
-        return this._post('quotes', quoteRequest, newHeaders, true);
     }
 
     /**

--- a/src/lib/model/lib/fxpRequests/index.js
+++ b/src/lib/model/lib/fxpRequests/index.js
@@ -1,0 +1,17 @@
+/**************************************************************************
+ *  (C) Copyright ModusBox Inc. 2019 - All rights reserved.               *
+ *                                                                        *
+ *  This file is made available under the terms of the license agreement  *
+ *  specified in the corresponding source code repository.                *
+ *                                                                        *
+ *  ORIGINAL AUTHOR:                                                      *
+ *       James Bush - james.bush@modusbox.com                             *
+ **************************************************************************/
+
+'use strict';
+
+
+const FxpBackendRequests = require('./fxpBackendRequests.js');
+
+
+module.exports = FxpBackendRequests;

--- a/src/lib/model/lib/fxpRequests/package.json
+++ b/src/lib/model/lib/fxpRequests/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@internal/requests",
+  "version": "0.0.1",
+  "description": "Wrappers around request-promise-native to simplify calling the FXP backend",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Matt Kingston, James Bush ModusBox Inc",
+  "license": "Apache-2.0",
+  "licenses": [
+    {
+      "type": "Apache-2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ],
+  "dependencies": {
+    "request": "^2.34",
+    "request-promise-native": "^1.0.7"
+  }
+}

--- a/src/lib/model/lib/requests/backendRequests.js
+++ b/src/lib/model/lib/requests/backendRequests.js
@@ -19,9 +19,18 @@ const common = require('./common.js');
 const buildUrl = common.buildUrl;
 const throwOrJson = common.throwOrJson;
 
+const defaultFXPBackendHeaders = {
+    accept: 'application/json',
+    // Mojaloop uses specific types like
+    // application/vnd.interoperability.quotes+json;version=1.0 and application/vnd.interoperability.transfers+json;version=1.0
+    // but the backend expects application/json
+    'content-type': 'application/json',
+};
 
 /**
  * A class for making requests to DFSP backend API
+ * 
+ * / FIXME Move the specific FXP methods to another class, so this one can be pulled from the original sdk project
  */
 class BackendRequests {
     constructor(config) {
@@ -64,7 +73,7 @@ class BackendRequests {
      * @returns {object} - JSON response body if one was received
      */
     async postQuotes(quoteRequest, headers) {
-
+        // Used to send the "second stage" quotes to a DFSP ( this is not the "simplified" quoterequest )
         const newHeaders = {
             accept: headers.accept,
             'content-type': headers['content-type'],
@@ -88,10 +97,6 @@ class BackendRequests {
      * @param {http-headers} headers 
      */
     async postFxpQuotes(quoteRequest, headers) {
-        const newHeaders = {
-            accept: headers.accept,
-            'content-type': headers['content-type'],
-        };
         const composedFXPQuote = {
             quote: quoteRequest,
             metadata:{
@@ -102,7 +107,7 @@ class BackendRequests {
             }
         };
 
-        return this._post('fxpquotes', composedFXPQuote, newHeaders);
+        return this._post('fxpquotes', composedFXPQuote, defaultFXPBackendHeaders);
     }
 
     /**
@@ -116,11 +121,6 @@ class BackendRequests {
      */
     async postFxpQuoteResponse(quoteId, quoteRequest, headers) {
 
-        const newHeaders = {
-            accept: headers.accept || 'application/vnd.interoperability.quotes+json;version=1',
-            'content-type': 'application/json', // headers['content-type'] is application/vnd.interoperability.quotes+json;version=1.0, but the backend expects application/json
-        };
-
         const composedQuoteResponse = {
             quoteResponse: quoteRequest,
             metadata:{
@@ -130,7 +130,7 @@ class BackendRequests {
         };
         
         console.log('postQuote sending headers: ', headers, ' quoteRequest: ', composedQuoteResponse);
-        return this._post(`fxpquotes/${quoteId}/responses`, composedQuoteResponse, newHeaders);
+        return this._post(`fxpquotes/${quoteId}/responses`, composedQuoteResponse, defaultFXPBackendHeaders);
     }
     
     
@@ -159,9 +159,9 @@ class BackendRequests {
      * @returns {object} - JSON response body if one was received
      */
     async postQuote(quoteId, quoteRequest, headers) {
-
+        // FIXME This is not used
         const newHeaders = {
-            accept: headers.accept || 'application/vnd.interoperability.quotes+json;version=1',
+            accept: headers.accept || 'application/json',
             'content-type': 'application/json', // headers['content-type'] is application/vnd.interoperability.quotes+json;version=1.0, but the backend expects application/json
             date: headers.date,
             'fspiop-source': headers['fspiop-source'],

--- a/src/lib/model/package.json
+++ b/src/lib/model/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "@internal/requests": "file:lib/requests",
+    "@internal/fxpRequests": "file:lib/fxpRequests",
     "@internal/shared": "file:lib/shared",
     "javascript-state-machine": "^3.1.0"
   }


### PR DESCRIPTION
It'd be best if we could keep the code from the modusbox/mojaloop-sdk-scheme-adapter untouched and add the FXP specifics as extensions.
In this PR, I move the code that makes requests to the new FXP Backend API into its own class, instead of mixing it with the original class that calls the Simplified DFSP Backend